### PR TITLE
Revert "Missing critical bug fix in 1.5.4"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ FROM dockerfile/ubuntu
 RUN \
   sed -i 's/^# \(.*-backports\s\)/\1/g' /etc/apt/sources.list && \
   apt-get update && \
-  apt-get install -y haproxy=1.5.6-1~ubuntu14.04.1 && \
+  apt-get install -y haproxy=1.5.3-1~ubuntu14.04.1 && \
   sed -i 's/^ENABLED=.*/ENABLED=1/' /etc/default/haproxy && \
   rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Reverts dockerfile/haproxy#5 since the build fails.
