### PR TITLE
Set haproxy as first process

### DIFF
--- a/start.bash
+++ b/start.bash
@@ -26,4 +26,4 @@ if [[ -f "$OVERRIDE/$CONFIG" ]]; then
   ln -s "$OVERRIDE/$CONFIG" "$CONFIG"
 fi
 
-haproxy -f /etc/haproxy/haproxy.cfg -p "$PIDFILE"
+exec haproxy -f /etc/haproxy/haproxy.cfg -p "$PIDFILE"


### PR DESCRIPTION
Add exec to have haproxy as the first process in the container, this will allow to have clean stop / restart with signal handled by haproxy
